### PR TITLE
Install Sqitch with PostreSQL, MySQL or SQLite support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,18 +24,32 @@ Variables
 ---------
 
 ```yml
-sqitch_database_support: PostgreSQL  # Can be any of [SQLite, MySQL, PostgrSQL]. Install sqitch with support to this database
+sqitch_database_support: 
+ - PostgreSQL  # Can be any of SQLite, MySQL, PostgrSQL. Install sqitch with support to this database. See Example Playbook for usage
 
 ```
 Example Playbook
 ----------------
-
-
-    - hosts: servers
+One database 
+```yml
+- hosts: servers
       roles:
          - role: ansible-sqitch
            vars:
-            sqitch_database_support: PostgreSQL
+            sqitch_database_support: 
+              - PostgreSQL
+```
+Multiple databases
+```yml
+- hosts: servers
+      roles:
+         - role: ansible-sqitch
+           vars:
+            sqitch_database_support: 
+              - PostgreSQL
+              - MySQL
+```
+
 
 Testing
 ------------

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 ansible-sqitch
 =========
 
-Ansible role that installs sqitch on Debian/Ubuntu.
+Ansible role that installs Sqitch with PostgreSQL, MySQL or SQLite support on Debian/Ubuntu.
+
 
 Requirements
 ------------
@@ -11,15 +12,30 @@ This role has no pre-requisites.
 Dependencies
 ------------
 
-This role has no dependencies.
+The dependencies depend on the database to install.
 
+PostgreSQL: `libdbd-pg-perl`, `postgresql-client`
+
+MySQL: `libdbd-mysql-perl`, `mysql-client`
+
+SQLite: `libdbd-sqlite3-perl`, `sqlite3`
+
+Variables
+---------
+
+```yml
+sqitch_database_support: PostgreSQL  # Can be any of [SQLite, MySQL, PostgrSQL]. Install sqitch with support to this database
+
+```
 Example Playbook
 ----------------
 
 
     - hosts: servers
       roles:
-         - ansible-sqitch
+         - role: ansible-sqitch
+           vars:
+            sqitch_database_support: PostgreSQL
 
 Testing
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 # defaults file for ansible-sqitch
-sqitch_database_support: PostgreSQL
+sqitch_database_support:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 # defaults file for ansible-sqitch
+sqitch_database_support: PostgreSQL

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -5,3 +5,8 @@
     - name: "Include ansible-sqitch"
       include_role:
         name: "ansible-sqitch"
+      vars:
+        sqitch_database_support:
+          - PostgreSQL
+          - MySQL
+          - SQLite

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -1,5 +1,5 @@
 import os
-
+import pytest
 import testinfra.utils.ansible_runner
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
@@ -16,3 +16,24 @@ def test_hosts_file(host):
 def test_sqitch_is_installed(host):
     sqitch_package = host.package("sqitch")
     assert sqitch_package.is_installed
+
+
+@pytest.mark.parametrize(
+    "postgres_packages", ["libdbd-pg-perl", "postgresql-client"])
+def test_postgres_packages_are_installed(host, postgres_packages):
+    pkg = host.package(postgres_packages)
+    assert pkg.is_installed
+
+
+@pytest.mark.parametrize(
+    "sqlite_packages", ["libdbd-sqlite3-perl", "sqlite3"])
+def test_sqlite_packages_are_installed(host, sqlite_packages):
+    pkg = host.package(sqlite_packages)
+    assert pkg.is_installed
+
+
+@pytest.mark.parametrize(
+    "mysql_packages", ["libdbd-mysql-perl", "mysql-client"])
+def test_mysql_packages_are_installed(host, mysql_packages):
+    pkg = host.package(mysql_packages)
+    assert pkg.is_installed

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -5,8 +5,7 @@
     state: latest
     update_cache: yes
     cache_valid_time: 600
-  when:
-    sqitch_database_support == 'PostgreSQL'
+  when: '"PostgreSQL" in sqitch_database_support'
 
 - name: Install Sqitch with SQLite support
   apt:
@@ -14,8 +13,7 @@
     state: latest
     update_cache: yes
     cache_valid_time: 600
-  when:
-    sqitch_database_support == 'SQLite'
+  when: '"SQLite" in sqitch_database_support'
 
 - name: Install Sqitch with MySQL support
   apt:
@@ -23,5 +21,4 @@
     state: latest
     update_cache: yes
     cache_valid_time: 600
-  when:
-    sqitch_database_support == 'MySQL'
+  when: '"MySQL" in sqitch_database_support'

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,0 +1,27 @@
+---
+- name: Install Sqitch with PostgreSQL support
+  apt:
+    pkg: ['sqitch', 'libdbd-pg-perl', 'postgresql-client']
+    state: latest
+    update_cache: yes
+    cache_valid_time: 600
+  when:
+    sqitch_database_support == 'PostgreSQL'
+
+- name: Install Sqitch with SQLite support
+  apt:
+    pkg: ['sqitch', 'libdbd-sqlite3-perl', 'sqlite3']
+    state: latest
+    update_cache: yes
+    cache_valid_time: 600
+  when:
+    sqitch_database_support == 'SQLite'
+
+- name: Install Sqitch with MySQL support
+  apt:
+    pkg: ['sqitch', 'libdbd-mysql-perl', 'mysql-client']
+    state: latest
+    update_cache: yes
+    cache_valid_time: 600
+  when:
+    sqitch_database_support == 'MySQL'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,6 @@
 ---
 # tasks file for ansible-sqitch
 - name: Install Sqitch
-  apt:
-    name: sqitch
-    update_cache: true
-    state: present
+  include_tasks: install.yml
+  tags:
+    - install


### PR DESCRIPTION
Install necessary requirements based on the database specified.
Allow multiple databases to be specified during installation.
fixes #3 